### PR TITLE
future instead of parallel, snowfall, ...

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,9 +8,8 @@ Depends: R (>= 2.15.0)
 Imports: graphics, methods, stats, utils, matrixStats (>= 0.15.0),
         R.utils (>= 2.2.0), Biobase (>= 2.18.0), CGHbase (>= 1.18.0),
         CGHcall (>= 2.18.0), DNAcopy (>= 1.32.0), Rsamtools (>= 1.20),
-        GenomicRanges (>= 1.20), IRanges (>= 2.2)
-Suggests: R.cache (>= 0.12.0), digest, snowfall, BSgenome, GenomeInfoDb,
-        parallel
+        GenomicRanges (>= 1.20), IRanges (>= 2.2), future (>= 0.11.0)
+Suggests: R.cache (>= 0.12.0), digest, BSgenome, GenomeInfoDb
 Description: Quantitative DNA sequencing for chromosomal aberrations.
         The genome is divided into non-overlapping fixed-sized bins, number of
         sequence reads in each counted, adjusted with a simultaneous

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -31,6 +31,7 @@ importFrom(stats, lm, loess, predict)
 importFrom(utils, packageVersion, read.table, write.table)
 importFrom(GenomicRanges, GRanges)
 importFrom(IRanges, IRanges)
+importFrom(future, future, values)
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # EXPORTS

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -9,8 +9,7 @@ setGeneric("correctBins", function(object, fit=NULL,
     method="ratio", adjustIncompletes=TRUE, ...)
     standardGeneric("correctBins"))
 setGeneric("estimateCorrection", function(object, span=0.65, family="symmetric",
-    adjustIncompletes=TRUE, maxIter=1, cutoff=4.0,
-    mc.cores=getOption("mc.cores", 2L), ...)
+    adjustIncompletes=TRUE, maxIter=1, cutoff=4.0, ...)
     standardGeneric("estimateCorrection"))
 setGeneric("highlightFilters", function(object, col="red", residual=NA,
     blacklist=NA, mappability=NA, bases=NA, type="union", ...)
@@ -30,7 +29,7 @@ setGeneric("poolRuns", function(object, samples, force=FALSE)
     standardGeneric("poolRuns"))
 setGeneric("segmentBins", function(object, smoothBy=FALSE,
     alpha=1e-10, undo.splits="sdundo", undo.SD=1.0,
-    force=FALSE, transformFun="log2", mc.cores=getOption("mc.cores", 2L), ...)
+    force=FALSE, transformFun="log2", ...)
     standardGeneric("segmentBins"))
 setGeneric("smoothOutlierBins", function(object,
     logTransform=TRUE, force=FALSE, ...)

--- a/R/createBinAnnotations.R
+++ b/R/createBinAnnotations.R
@@ -124,9 +124,16 @@ calculateMappability <- function(bins, bigWigFile,
     map$V5 * 100
 }
 
-calculateBlacklist <- function(bins, bedFiles, ncpus=1) {
+calculateBlacklist <- function(bins, bedFiles, ...) {
     vmsg("Calculating overlaps per bin with BED files \n    ", paste(bedFiles,
         collapse="\n    "), "\n    ...", appendLF=FALSE)
+
+    ## Detected deprecated usage of argument 'ncpus'
+    args <- list(...)
+    if ("ncpus" %in% names(args)) {
+      .Deprecated(msg="Argument 'ncpus' of calculateBlacklist() is deprecated and ignored. Use options(mc.cores=ncpu) instead.")
+    }
+
     beds <- list()
     for (bed in bedFiles)
         beds[[bed]] <- read.table(bed, sep="\t", as.is=TRUE)

--- a/R/createBinAnnotations.R
+++ b/R/createBinAnnotations.R
@@ -128,7 +128,7 @@ calculateBlacklist <- function(bins, bedFiles, ...) {
     vmsg("Calculating overlaps per bin with BED files \n    ", paste(bedFiles,
         collapse="\n    "), "\n    ...", appendLF=FALSE)
 
-    ## Detected deprecated usage of argument 'ncpus'
+    ## Detect deprecated usage of argument 'ncpus'
     args <- list(...)
     if ("ncpus" %in% names(args)) {
       .Deprecated(msg="Argument 'ncpus' of calculateBlacklist() is deprecated and ignored. Use options(mc.cores=ncpu) instead.")

--- a/R/createBinAnnotations.R
+++ b/R/createBinAnnotations.R
@@ -19,7 +19,7 @@
 #         in units of kbp (1000 base pairs), e.g. \code{binSize=15} corresponds
 #         to 15 kbp bins.}
 #     \item{ignoreMitochondria}{Whether to ignore the mitochondria.}
-#     \item{excludeSeqnames}{Character vector of seqnames which should be 
+#     \item{excludeSeqnames}{Character vector of seqnames which should be
 #         ignored.}
 # }
 #
@@ -51,7 +51,7 @@
 #     @see "getBinAnnotations".
 # }
 #*/#########################################################################
-createBins <- function(bsgenome, binSize, ignoreMitochondria=TRUE, 
+createBins <- function(bsgenome, binSize, ignoreMitochondria=TRUE,
     excludeSeqnames=NULL) {
     chrs <- GenomeInfoDb::seqnames(bsgenome)
     try({
@@ -173,14 +173,7 @@ calculateBlacklist <- function(bins, bedFiles, ncpus=1) {
                 max(start, overlaps[i, "start"]) + 1
         bases / (end - start + 1) * 100
     }
-    if (ncpus > 1L) {
-        snowfall::sfInit(parallel=TRUE, cpus=ncpus)
-        snowfall::sfExport(list=c("overlap.counter"))
-        blacklist <- snowfall::sfApply(bins, 1, overlap.counter, joined)
-        snowfall::sfStop()
-    } else {
-        blacklist <- apply(bins, MARGIN=1L, FUN=overlap.counter, joined)
-    }
+    blacklist <- fapply(bins, MARGIN=1L, FUN=overlap.counter, joined)
     vmsg()
     blacklist
 }

--- a/R/estimateCorrection.R
+++ b/R/estimateCorrection.R
@@ -31,11 +31,6 @@
 #         (as estimated with @see "matrixStats::madDiff") the cutoff for removal
 #         of bins with median residuals larger than the cutoff. Not used if
 #         \code{maxIter=1} (default).}
-#     \item{mc.cores}{If package \pkg{parallel} is installed, the number of
-#         cores to use, i.e. at most how many child processes will be run
-#         simultaneously. The option is initialized from environment variable
-#         ‘MC_CORES’ if set. Must be at least one, and parallelization
-#         requires at least two cores.}
 #     \item{...}{Additional aguments passed to @see "stats::loess".}
 # }
 #
@@ -64,7 +59,7 @@
 setMethod("estimateCorrection", signature=c(object="QDNAseqReadCounts"),
     definition=function(object, span=0.65, family="symmetric",
     adjustIncompletes=TRUE, maxIter=1, cutoff=4.0,
-    mc.cores=getOption("mc.cores", 2L), ...) {
+    ...) {
 
     counts <- assayDataElement(object, "counts")
     if (adjustIncompletes) {
@@ -149,12 +144,7 @@ setMethod("estimateCorrection", signature=c(object="QDNAseqReadCounts"),
         attr(loessFit, "used.family") <- NA
         return(loessFit)
     }
-    if ("parallel" %in% .packages(all.available=TRUE) && mc.cores > 1) {
-        fits <- parallel::mclapply(seq_len(ncol(counts)), calculateFits, ...,
-        mc.cores=mc.cores)
-    } else {
-        fits <- lapply(seq_len(ncol(counts)), calculateFits, ...)
-    }
+    fits <- flapply(seq_len(ncol(counts)), calculateFits, ...)
     loessFit <- do.call(cbind, fits)
     dimnames(loessFit) <- dimnames(counts)
     object$loess.span <- unlist(lapply(fits, attr, which="used.span"))
@@ -163,5 +153,5 @@ setMethod("estimateCorrection", signature=c(object="QDNAseqReadCounts"),
     vmsg("Done.")
     object
 })
-    
+
 # EOF

--- a/R/segmentBins.R
+++ b/R/segmentBins.R
@@ -32,11 +32,6 @@
 #         stabilizes the variance, "none" for no transformation, or any
 #         R function that performs the desired transformation and also its
 #         inverse when called with parameter \code{inv=TRUE}.}
-#     \item{mc.cores}{If package \pkg{parallel} is installed, the number of
-#         cores to use, i.e. at most how many child processes will be run
-#         simultaneously. The option is initialized from environment variable
-#         ‘MC_CORES’ if set. Must be at least one, and parallelization
-#         requires at least two cores.}
 #     \item{...}{Additional arguments passed to @see "DNAcopy::segment".}
 # }
 #
@@ -69,7 +64,7 @@
 setMethod("segmentBins", signature=c(object="QDNAseqCopyNumbers"),
     definition=function(object, smoothBy=FALSE, alpha=1e-10,
     undo.splits="sdundo", undo.SD=1.0, force=FALSE,
-    transformFun="log2", mc.cores=getOption("mc.cores", 2L), ... ) {
+    transformFun="log2", ... ) {
 
     if (!force && "calls" %in% assayDataElementNames(object))
         stop("Data has already been called. Re-segmentation will ",
@@ -111,12 +106,11 @@ setMethod("segmentBins", signature=c(object="QDNAseqCopyNumbers"),
 
     # if (is.na(smoothBy) || !smoothBy || smoothBy <= 1) {
     if (is.na(smoothBy) || !smoothBy) {
-        ## create a list of CNA objects that can be analyzed with mclapply()
-        ## for parallel processing, or lapply() for serial
+        ## create a list of CNA objects that can be analyzed with *lapply()
         cna <- lapply(sampleNames(object), function(x)
             CNA(genomdat=copynumber[condition, x, drop=FALSE],
                 chrom=factor(fData(object)$chromosome[condition],
-                    levels=unique(fData(object)$chromosome), ordered=TRUE), 
+                    levels=unique(fData(object)$chromosome), ordered=TRUE),
                 maploc=fData(object)$start[condition], data.type="logratio",
                 sampleid=x, presorted=TRUE))
         ## create a vector of messages to be printed
@@ -125,21 +119,13 @@ setMethod("segmentBins", signature=c(object="QDNAseqCopyNumbers"),
         ## use sample names for indexing, they are available in the CNA objects
         ## as the name of the third column
         names(msgs) <- sampleNames(object)
-        if ("parallel" %in% .packages(all.available=TRUE) && mc.cores > 1) {
-            segments <- parallel::mclapply(cna, FUN=function(x, ...) {
-                vmsg(msgs[colnames(x)[3]])
-                segment(x, alpha=alpha, undo.splits=undo.splits,
-                    undo.SD=undo.SD, verbose=0, ...)
-            }, ..., mc.cores=mc.cores)
-        } else {
-            segments <- lapply(cna, FUN=function(x, ...) {
-                vmsg(msgs[colnames(x)[3]], appendLF=FALSE)
-                seg <- segment(x, alpha=alpha, undo.splits=undo.splits,
-                    undo.SD=undo.SD, verbose=0, ...)
-                vmsg()
-                seg
-            }, ...)
-        }
+        segments <- flapply(cna, FUN=function(x, ...) {
+            vmsg(msgs[colnames(x)[3]], appendLF=FALSE)
+            seg <- segment(x, alpha=alpha, undo.splits=undo.splits,
+                undo.SD=undo.SD, verbose=0, ...)
+            vmsg()
+            seg
+        }, ...)
         segmented <- do.call(cbind, lapply(segments, function(x)
             rep(x$output$seg.mean, x$output$num.mark)))
         dimnames(segmented) <- dimnames(copynumber[condition, , drop=FALSE])
@@ -166,22 +152,14 @@ setMethod("segmentBins", signature=c(object="QDNAseqCopyNumbers"),
             }
         )
 
-        if ("parallel" %in% .packages(all.available=TRUE) && mc.cores > 1) {
-            segments <- parallel::mclapply(cna, FUN=function(x, ...) {
-                vmsg("    Segmenting chromosome ", x$chrom[1], " ...")
-                segment(x, alpha=alpha, undo.splits=undo.splits,
-                    undo.SD=undo.SD, verbose=0, ...)
-            }, ..., mc.cores=mc.cores)
-        } else {
-            segments <- lapply(cna, FUN=function(x, ...) {
-                vmsg("    Segmenting chromosome ", x$chrom[1], " ...",
-                    appendLF=FALSE)
-                seg <- segment(x, alpha=alpha, undo.splits=undo.splits,
-                    undo.SD=undo.SD, verbose=0, ...)
-                vmsg()
-                seg
-            }, ...)
-        }
+        segments <- flapply(cna, FUN=function(x, ...) {
+            vmsg("    Segmenting chromosome ", x$chrom[1], " ...",
+                appendLF=FALSE)
+            seg <- segment(x, alpha=alpha, undo.splits=undo.splits,
+                undo.SD=undo.SD, verbose=0, ...)
+            vmsg()
+            seg
+        }, ...)
 
         segmented <- do.call(rbind, lapply(segments, function(x) {
             chrSegmented <- matrix(NA_real_, nrow=nrow(x$data),

--- a/R/segmentBins.R
+++ b/R/segmentBins.R
@@ -120,11 +120,9 @@ setMethod("segmentBins", signature=c(object="QDNAseqCopyNumbers"),
         ## as the name of the third column
         names(msgs) <- sampleNames(object)
         segments <- flapply(cna, FUN=function(x, ...) {
-            vmsg(msgs[colnames(x)[3]], appendLF=FALSE)
-            seg <- segment(x, alpha=alpha, undo.splits=undo.splits,
-                undo.SD=undo.SD, verbose=0, ...)
-            vmsg()
-            seg
+            vmsg(msgs[colnames(x)[3]])
+            segment(x, alpha=alpha, undo.splits=undo.splits,
+                    undo.SD=undo.SD, verbose=0, ...)
         }, ...)
         segmented <- do.call(cbind, lapply(segments, function(x)
             rep(x$output$seg.mean, x$output$num.mark)))
@@ -153,12 +151,9 @@ setMethod("segmentBins", signature=c(object="QDNAseqCopyNumbers"),
         )
 
         segments <- flapply(cna, FUN=function(x, ...) {
-            vmsg("    Segmenting chromosome ", x$chrom[1], " ...",
-                appendLF=FALSE)
-            seg <- segment(x, alpha=alpha, undo.splits=undo.splits,
-                undo.SD=undo.SD, verbose=0, ...)
-            vmsg()
-            seg
+            vmsg("    Segmenting chromosome ", x$chrom[1], " ...")
+            segment(x, alpha=alpha, undo.splits=undo.splits,
+                    undo.SD=undo.SD, verbose=0, ...)
         }, ...)
 
         segmented <- do.call(rbind, lapply(segments, function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,15 @@
+## Until the future package provides a well-defined *apply() API
+## we define futurized versions of lapply() and apply() here.
+flapply <- function(x, FUN, ...) {
+  res <- list()
+  for (ii in seq_along(x)) res[[ii]] <- future(FUN(x[[ii]], ...))
+  names(res) <- names(x)
+  values(res)
+}
+
+fapply <- function(X, MARGIN, FUN, ...) {
+  fFUN <- function(...) { future(FUN(...)) }
+  res <- apply(X, MARGIN=1L, FUN=fFUN, ...)
+  res <- values(res)
+  sapply(res, FUN=I, simplify=TRUE)
+}

--- a/man/QDNAseq-package.Rd
+++ b/man/QDNAseq-package.Rd
@@ -32,10 +32,13 @@
 
 \section{How to cite this package}{
     Whenever using this package, please cite:
-    Scheinin I, Sie D, Bengtsson H, van de Wiel MA, Olshen AB, van Thuijl HF, van Essen HF, Eijk PP, Rustenburg F, Meijer GA,
-Reijneveld JC, Wesseling P, Pinkel D, Albertson DG and Ylstra B (2014). "DNA copy number analysis of fresh and
-formalin-fixed specimens by shallow whole-genome sequencing with identification and exclusion of problematic regions in the
-genome assembly." _Genome Research_, *24*, pp. 2022-2032.
+    Scheinin I, Sie D, Bengtsson H, van de Wiel MA, Olshen AB, van Thuijl
+HF, van Essen HF, Eijk PP, Rustenburg F, Meijer GA, Reijneveld JC,
+Wesseling P, Pinkel D, Albertson DG and Ylstra B (2014). "DNA copy
+number analysis of fresh and formalin-fixed specimens by shallow
+whole-genome sequencing with identification and exclusion of
+problematic regions in the genome assembly." _Genome Research_, *24*,
+pp. 2022-2032.
 }
 
 \author{Ilari Scheinin}

--- a/man/estimateCorrection.Rd
+++ b/man/estimateCorrection.Rd
@@ -16,7 +16,7 @@
 
 \usage{
 estimateCorrection(object, span=0.65, family="symmetric", adjustIncompletes=TRUE,
-  maxIter=1, cutoff=4, mc.cores=getOption("mc.cores", 2L), ...)
+  maxIter=1, cutoff=4, ...)
 }
 
 \description{
@@ -43,11 +43,6 @@ estimateCorrection(object, span=0.65, family="symmetric", adjustIncompletes=TRUE
         (as estimated with \code{\link[matrixStats]{madDiff}}) the cutoff for removal
         of bins with median residuals larger than the cutoff. Not used if
         \code{maxIter=1} (default).}
-    \item{mc.cores}{If package \pkg{parallel} is installed, the number of
-        cores to use, i.e. at most how many child processes will be run
-        simultaneously. The option is initialized from environment variable
-        ‘MC_CORES’ if set. Must be at least one, and parallelization
-        requires at least two cores.}
     \item{...}{Additional aguments passed to \code{\link[stats]{loess}}.}
 }
 

--- a/man/segmentBins.Rd
+++ b/man/segmentBins.Rd
@@ -15,8 +15,8 @@
 \title{Segments normalized copy number data}
 
 \usage{
-segmentBins(object, smoothBy=FALSE, alpha=0.0000000001, undo.splits="sdundo", undo.SD=1,
-  force=FALSE, transformFun="log2", mc.cores=getOption("mc.cores", 2L), ...)
+segmentBins(object, smoothBy=FALSE, alpha=1e-10, undo.splits="sdundo", undo.SD=1,
+  force=FALSE, transformFun="log2", ...)
 }
 
 \description{
@@ -44,11 +44,6 @@ segmentBins(object, smoothBy=FALSE, alpha=0.0000000001, undo.splits="sdundo", un
         stabilizes the variance, "none" for no transformation, or any
         R function that performs the desired transformation and also its
         inverse when called with parameter \code{inv=TRUE}.}
-    \item{mc.cores}{If package \pkg{parallel} is installed, the number of
-        cores to use, i.e. at most how many child processes will be run
-        simultaneously. The option is initialized from environment variable
-        ‘MC_CORES’ if set. Must be at least one, and parallelization
-        requires at least two cores.}
     \item{...}{Additional arguments passed to \code{\link[DNAcopy]{segment}}.}
 }
 


### PR DESCRIPTION
Hey, here is what I mean/propose.  Note also how you don't have to worry about globals etc, i.e. no need to export variables and so on.  They are automatically detected, and so are needed packages, and whatever backend is used, it will just work.

FYI, `plan(multicore)` uses the `parallel` "mc" machinery, `plan(multisession)` the `parallel` "snow/PSOCK" machinery.  There's also `plan(cluster)` for running on an ad hoc cluster.  I have another package for distributed processing on schedulers, e.g. `plan(async::batchjobs)`.  The implementation of QDNAseq does not have to know about the backend at all!

Also, there is an future assignment operator `%<=%` that allow you to use for loops etc, so you don't have to create special functions (as you had to do here), but I left that out.  For details, see https://cran.r-project.org/web/packages/future/vignettes/future.html
# Example run with 3 LGG150 samples:

``` r
## Default evaluation mode is to use eager futures (=plain R).
## This can be changed as:
## * plan(multicore)
## * options(future.plan=multicore)
## * export R_FUTURE_PLAN=multicore

> t0 <- system.time(fit <- segmentBins(dataN))
Performing segmentation:
    Segmenting: LGG150 (1 of 3) ...
    Segmenting: B (2 of 3) ...
    Segmenting: C (3 of 3) ...

## Use all alloted cores (respects mc.cores)
> future::plan("multicore")
> t1 <- system.time(fit <- segmentBins(dataN))
Performing segmentation:
    Segmenting: LGG150 (1 of 3) ...    Segmenting: B (2 of 3) ...    Segmenting: C (3 of 3) ...


## Use background R sessions (respects mc.cores) - also on Windows
> future::plan("multisession")
> t2 <- system.time(fit <- segmentBins(dataN))
Performing segmentation:

## Use 2 cores
> options(mc.cores=2L)
> future::plan("multicore")
> t1b <- system.time(fit <- segmentBins(dataN))
Performing segmentation:
    Segmenting: LGG150 (1 of 3) ...    Segmenting: B (2 of 3) ...    Segmenting: C (3 of 3) ...

## Alternative syntax allowing you to specify a backend for a particular call
> fit <- segmentBins(dataN) %plan% multicore
```
## Benchmark results

``` r
> t0
   user  system elapsed
 11.055   0.003  11.077
> t1
   user  system elapsed
 11.466   0.244   5.048
> t2
   user  system elapsed
  1.168   2.394   5.387
```
